### PR TITLE
Fix steerTempUnavailable: panda firmware rebuild workflow + path_angle clip fix

### DIFF
--- a/.github/workflows/build_panda.yml
+++ b/.github/workflows/build_panda.yml
@@ -1,0 +1,79 @@
+name: Build Panda Firmware
+
+# Trigger manually, or automatically when ford.h or panda board source changes
+on:
+  workflow_dispatch:
+  push:
+    branches: [dev, claude/brave-napier]
+    paths:
+      - 'opendbc_repo/opendbc/safety/modes/ford.h'
+      - 'panda/board/**'
+
+jobs:
+  build-panda-firmware:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Install ARM cross-compiler and scons
+      - name: Install build tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            gcc-arm-none-eabi \
+            binutils-arm-none-eabi \
+            scons \
+            python3-pip
+          pip3 install pycryptodome
+
+      # The panda board C source is in panda/board/ but needs a SConstruct.
+      # Fetch it from commaai/panda master (the upstream this fork is based on).
+      - name: Fetch SConstruct from commaai/panda
+        run: |
+          curl -fsSL \
+            "https://raw.githubusercontent.com/commaai/panda/master/board/SConstruct" \
+            -o panda/board/SConstruct
+
+      # The panda firmware includes "opendbc/safety/safety.h".
+      # The SConstruct adds panda/ to the include path, so it looks for panda/opendbc/.
+      # Symlink panda/opendbc -> opendbc_repo/opendbc so it uses OUR updated ford.h.
+      - name: Wire up custom opendbc include path
+        run: |
+          ln -sf "$GITHUB_WORKSPACE/opendbc_repo/opendbc" \
+                 "$GITHUB_WORKSPACE/panda/opendbc"
+          # Verify the ford.h we want is accessible
+          test -f panda/opendbc/safety/modes/ford.h && echo "ford.h found" || exit 1
+
+      # Build the panda H7 firmware in DEBUG mode (no signing cert needed)
+      - name: Build panda firmware
+        run: |
+          cd panda/board
+          ALLOW_DEBUG=1 scons -u
+
+      # Verify the binary was produced
+      - name: Verify build output
+        run: |
+          ls -la panda/board/obj/panda_h7/main.bin
+          # Copy unsigned debug binary to the standard flashing location
+          cp panda/board/obj/panda_h7/main.bin \
+             panda/board/obj/panda_h7.bin.signed
+
+      # Commit and push the updated binary back to your branch
+      - name: Commit updated firmware binary
+        run: |
+          git config user.email "github-actions@github.com"
+          git config user.name "GitHub Actions [panda build]"
+          git add panda/board/obj/panda_h7/main.bin
+          git add panda/board/obj/panda_h7.bin.signed
+          git add panda/board/obj/bootstub.panda_h7.bin 2>/dev/null || true
+          git add panda/board/obj/gitversion.h 2>/dev/null || true
+          # Only commit if something changed
+          git diff --staged --quiet && echo "Firmware unchanged" && exit 0
+          git commit -m "ci: rebuild panda firmware with updated ford.h c1/c0 safety code"
+          git push

--- a/opendbc_repo/opendbc/car/ford/carcontroller.py
+++ b/opendbc_repo/opendbc/car/ford/carcontroller.py
@@ -140,14 +140,15 @@ class CarController(CarControllerBase):
           d_c0 = float(np.interp(v_ego, [11., 14.], [d_look, 6.0]))
           path_offset = float(np.interp(d_c0, x_pts, np.array(self.model.position.y)))
 
-          path_angle = apply_std_steer_angle_limits(
-            path_angle, self.path_angle_last, v_ego, 0., CC.latActive, CarControllerParams.C1_RATE_LIMITS)
-
           ramp_type = 3
 
           apply_curvature = float(clip(apply_curvature, -0.02, 0.02))
           path_offset = float(clip(path_offset, -4.61, 4.60))
+          # Clip raw model value to DBC range before rate-limiting so the limiter
+          # tracks the clamped target, not the unbounded model prediction.
           path_angle = float(clip(path_angle, -0.475, 0.497))
+          path_angle = apply_std_steer_angle_limits(
+            path_angle, self.path_angle_last, v_ego, 0., CC.latActive, CarControllerParams.C1_RATE_LIMITS)
         else:
           # Non-CAN FD: curvature-only control (unchanged from upstream)
           # Bronco and some other cars consistently overshoot curv requests


### PR DESCRIPTION
## Summary

- **Root cause diagnosed**: The pre-built panda firmware binary (`panda/board/obj/panda_h7.bin.signed`) was compiled on 2026-04-12 — before the `ford.h` safety changes that allow non-zero `path_angle` (c1) and `path_offset` (c0) in `LateralMotionControl2`. The old binary contained this unconditional safety check:
  ```c
  // OLD — in the compiled binary, blocks all non-zero c1/c0:
  bool violation = (raw_path_angle != FORD_INACTIVE_PATH_ANGLE)
                || (raw_path_offset != FORD_INACTIVE_PATH_OFFSET);
  ```
  This caused panda to silently drop every `LateralMotionControl2` message with non-zero c1/c0. The PSCM never received the mode=2 activation command, stayed at `LatCtlSte_D_Stat=0`, and `carstate.py` triggered `steerFaultTemporary` → `steerTempUnavailable` immediately on engagement.

- **Add `.github/workflows/build_panda.yml`**: CI workflow that rebuilds the panda H7 firmware from the C source already committed in `panda/board/`, wiring the include path to `opendbc_repo/opendbc/` (which has the correct updated `ford.h`). Commits the resulting `panda_h7.bin.signed` back to the branch. Run it via **Actions → Build Panda Firmware → Run workflow**.

- **Fix `path_angle` clip ordering in `carcontroller.py`**: Moved the `clip(-0.475, 0.497)` call to happen *before* `apply_std_steer_angle_limits`, so the rate limiter tracks the clamped target rather than the unbounded raw model prediction.

## What the workflow does

1. Installs `gcc-arm-none-eabi` + `scons` on Ubuntu 22.04
2. Fetches the `SConstruct` from `commaai/panda` master
3. Creates `panda/opendbc → opendbc_repo/opendbc` symlink so `#include "opendbc/safety/safety.h"` resolves to the fork's updated `ford.h`
4. Builds with `ALLOW_DEBUG=1` (no signing cert needed for dev builds)
5. Commits `panda_h7.bin.signed` + `main.bin` back to the branch

## Test plan

- [ ] Run **Actions → Build Panda Firmware → Run workflow** on `dev` branch
- [ ] Confirm workflow succeeds and commits a new `panda_h7.bin.signed`
- [ ] Pull update to device (`git pull` + restart openpilot)
- [ ] Confirm pandad reflashes panda on startup (check logs for "Panda firmware out of date, update required")
- [ ] Activate steering on a CAN FD Ford vehicle — `steerTempUnavailable` should not appear immediately
- [ ] Confirm `LatCtlSte_D_Stat` transitions to 2 (Active) in CAN logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)