### PR TITLE
fix(ford): zero c2 curvature and fix ramp_type on standby→active transition

### DIFF
--- a/opendbc_repo/opendbc/car/ford/carcontroller.py
+++ b/opendbc_repo/opendbc/car/ford/carcontroller.py
@@ -236,7 +236,21 @@ class CarController(CarControllerBase):
             path_angle = apply_std_steer_angle_limits(
               path_angle, self.path_angle_last, v_ego, 0., canfd_lat_active, CarControllerParams.C1_RATE_LIMITS)
 
-            ramp_type = 3
+            # FIX 1: c2 must be ~0 when c0/c1 are handling the steering (mode=2 design intent,
+            # per ford.h comment "c2=0 always"). Sending full desired_curvature (c2) alongside
+            # model-derived path_angle (c1) double-counts the road curvature in the PSCM's path
+            # polynomial y(x)=c0+c1*x+c2*x²/2. On a curve the combined c1*x + c2*x²/2 term
+            # commands an excessively large lateral correction (e.g. 2+ m at 20m lookahead),
+            # causing the PSCM to hit its servo limit and fault → LatCtlSte_D_Stat=4 →
+            # steerFaultTemporary → steerTempUnavailable.
+            apply_curvature = 0.0
+
+            # FIX 2: avoid an immediate-ramp steering jerk on the standby→active transition.
+            # ramp_type=3 (Immediate) while PSCM is still in standby (state=1) causes a sudden
+            # step command that can fault the PSCM. Switch to Immediate only once the PSCM
+            # confirms it is active (state=2). Use Medium ramp for the first engagement frame.
+            canfd_ste_status = getattr(CS, "lat_ctl_ste_status", 1)
+            ramp_type = 3 if canfd_ste_status == 2 else 1
 
             path_offset_limit = float(np.interp(v_ego, *CarControllerParams.C0_MAX))
             path_offset = float(clip(path_offset, -path_offset_limit, path_offset_limit))


### PR DESCRIPTION
## Summary

- **Fix steerTempUnavailable on Ford CAN FD path-following activation**

Two bugs in `carcontroller.py` caused the PSCM to fault immediately upon activation whenever the model sent a steering command.

### Bug 1 — Double-counted road curvature (c2 + c1)

The PSCM evaluates the path polynomial `y(x) = c0 + c1·x + c2·x²/2`. The previous code sent **both**:
- `path_angle` (c1) derived from the model's predicted orientation — which already encodes the road heading
- `apply_curvature` (c2) from `desired_curvature` — which also encodes the road curvature

On any curve, these two terms reinforce each other. At 20 m lookahead on a gentle curve, the combined command can exceed 2 m of lateral correction — well past the PSCM's servo limit. The PSCM faults, `LatCtlSte_D_Stat` goes to 4+, and `steerFaultTemporary` → `steerTempUnavailable` fires every activation.

**Fix:** Set `apply_curvature = 0.0` inside the model block. When in PathFollowingExtendedMode (mode=2), c1/c0 carry the full steering intent; c2 must be zero (as noted in ford.h's own comment "c2=0 always").

### Bug 2 — Immediate ramp on first engagement frame

`ramp_type = 3` (Immediate) was unconditionally set whenever model data was available, including the very first frame after engagement when the PSCM is still in standby (`LatCtlSte_D_Stat = 1`). A sudden non-zero c0/c1 command with Immediate ramp on a standby PSCM can trigger a fault.

**Fix:** Gate `ramp_type = 3` on `LatCtlSte_D_Stat == 2` (Active). Use `ramp_type = 1` (Medium) on the engagement frame while the PSCM is still transitioning to active.

## Test plan

- [ ] Flash updated firmware (panda binary with c0/c1 safety support already on dev)
- [ ] Activate lateral control on a straight road — confirm no `steerTempUnavailable`
- [ ] Activate on a gentle curve — confirm PSCM stays in state 2 (Active), no fault
- [ ] Check `LatCtlSte_D_Stat` stays in {1, 2, 3} throughout activation and override
- [ ] Confirm `steerFaultTemporary` does not trigger in the first few seconds after engagement

🤖 Generated with [Claude Code](https://claude.com/claude-code)